### PR TITLE
added notebook to save the image metadata in a csv file

### DIFF
--- a/resources/csv_generator.ipynb
+++ b/resources/csv_generator.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import csv\n",
+    "from tqdm import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# find the current path\n",
+    "\n",
+    "current_directory = os.path.dirname(os.path.abspath('__file__'))\n",
+    "image_directory = 'test_images'\n",
+    "directory_to_scan = os.path.join(current_directory, image_directory)\n",
+    "\n",
+    "if os.path.exists(directory_to_scan):\n",
+    "    print(True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#generator\n",
+    "def load_images_from_harddrive(root_dir):\n",
+    "    for root, dirs, files in os.walk(root_dir):\n",
+    "        print(len(files))\n",
+    "        for file in files:\n",
+    "            if file.lower().endswith((\".jpg\", \".png\", \".jpeg\")):\n",
+    "                file_path = os.path.join(root, file)\n",
+    "                size = os.path.getsize(file_path)\n",
+    "                yield root, file, size\n",
+    "\n",
+    "gen = load_images_from_harddrive(directory_to_scan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# declare where the csv file should be saved\n",
+    "output_path = os.path.join(current_directory, 'image_info.csv')\n",
+    "fieldnames = ['image_id', 'root', 'file', 'size']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(output_path, 'w', newline='') as csvfile:\n",
+    "    writer = csv.DictWriter(csvfile, fieldnames=fieldnames)\n",
+    "    writer.writeheader()\n",
+    "\n",
+    "    image_id = 1\n",
+    "\n",
+    "    for root, file, size in tqdm(gen):\n",
+    "        writer.writerow({\n",
+    "            'image_id': image_id,\n",
+    "            'root': root,\n",
+    "            'file': file,\n",
+    "            'size': size\n",
+    "        })\n",
+    "        image_id += 1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.12 (main, Apr  5 2022, 01:53:17) \n[Clang 12.0.0 ]"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "c24ecc2928a1df641fb89905a028e959d05eac4f79c1af53f0bb766b01409011"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
With this notebook we can directly save the metadata of the images in a csv file. This is faster then directly appending it into a database. At the end we can convert the csv-data into a sqlite database. 